### PR TITLE
Fix aliasing issue with 'sort' in update_all_dependencies.ps1

### DIFF
--- a/src/NetDaemon.Templates.Project/templates/netdaemon/update_all_dependencies.ps1
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon/update_all_dependencies.ps1
@@ -4,16 +4,16 @@ dotnet tool update joysoftware.netdaemon.hassmodel.codegen
 # Update all nugets to latest versions
 $regex = 'PackageReference Include="([^"]*)" Version="([^"]*)"'
 
-ForEach ($file in get-childitem . -recurse | where { $_.extension -like "*proj" }) {
+ForEach ($file in Get-ChildItem . -Recurse | Where-Object { $_.Extension -like "*proj" }) {
     $packages = Get-Content $file.FullName |
-    select-string -pattern $regex -AllMatches | 
-    ForEach-Object { $_.Matches } | 
-    ForEach-Object { $_.Groups[1].Value.ToString() } | 
-    sort -Unique
+    Select-String -Pattern $regex -AllMatches | 
+        ForEach-Object { $_.Matches } | 
+        ForEach-Object { $_.Groups[1].Value.ToString() } | 
+        Sort-Object -Unique
     
     ForEach ($package in $packages) {
-        write-host "Update $file package :$package"  -foreground 'magenta'
+        Write-Host "Update $file package :$package"  -ForegroundColor Magenta
         $fullName = $file.FullName
-        iex "dotnet add $fullName package $package"
+        Invoke-Expression "dotnet add $fullName package $package"
     }
 }

--- a/src/NetDaemon.Templates.Project/templates/netdaemon_src/update_all_dependencies.ps1
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon_src/update_all_dependencies.ps1
@@ -4,16 +4,16 @@ dotnet tool update joysoftware.netdaemon.hassmodel.codegen
 # Update all nugets to latest versions
 $regex = 'PackageReference Include="([^"]*)" Version="([^"]*)"'
 
-ForEach ($file in get-childitem . -recurse | where { $_.extension -like "*proj" }) {
+ForEach ($file in Get-ChildItem . -Recurse | Where-Object { $_.Extension -like "*proj" }) {
     $packages = Get-Content $file.FullName |
-    select-string -pattern $regex -AllMatches | 
-    ForEach-Object { $_.Matches } | 
-    ForEach-Object { $_.Groups[1].Value.ToString() } | 
-    sort -Unique
+    Select-String -Pattern $regex -AllMatches | 
+        ForEach-Object { $_.Matches } | 
+        ForEach-Object { $_.Groups[1].Value.ToString() } | 
+        Sort-Object -Unique
     
     ForEach ($package in $packages) {
-        write-host "Update $file package :$package"  -foreground 'magenta'
+        Write-Host "Update $file package :$package"  -ForegroundColor Magenta
         $fullName = $file.FullName
-        iex "dotnet add $fullName package $package"
+        Invoke-Expression "dotnet add $fullName package $package"
     }
 }


### PR DESCRIPTION
There was a clash between `Sort-Object` and `/usr/bin/sort` when running `pwsh ./update_all_dependencies.ps1` in the DevContainer.

This pull request resolves the issue by spelling out the full commandLet name. It also cleans up the rest of the script to use full commandLet and parameter names throughout, which is Microsoft's recommendation and should prevent any other similar issues from popping up (however unlikely).