### PR TITLE
Add appsettings.Development to .gitignore

### DIFF
--- a/src/NetDaemon.Templates.Project/templates/netdaemon/.gitignore
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon/.gitignore
@@ -1,6 +1,8 @@
 obj
 bin
-#appsettings.json
+appsettings.Development.json
 .vs
 *.gen
 .idea
+#appsettings.json
+#HomeAssistantGenerated.cs

--- a/src/NetDaemon.Templates.Project/templates/netdaemon_src/.gitignore
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon_src/.gitignore
@@ -1,6 +1,8 @@
 obj
 bin
-#appsettings.json
+appsettings.Development.json
 .vs
 *.gen
 .idea
+#appsettings.json
+#HomeAssistantGenerated.cs


### PR DESCRIPTION
Adding default appsettings.Development to .gitignore to make sure users do not accententially upload their HA settings to git repo