### PR TITLE
Update to use expected version of codegen tool

### DIFF
--- a/src/NetDaemon.Templates.Project/templates/netdaemon/.config/dotnet-tools.json
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon/.config/dotnet-tools.json
@@ -1,12 +1,12 @@
 {
-    "version": 1,
-    "isRoot": true,
-    "tools": {
-      "joysoftware.netdaemon.hassmodel.codegen": {
-        "version": "22.34.0",
-        "commands": [
-          "nd-codegen"
-        ]
-      }
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "netdaemon.hassmodel.codegen": {
+      "version": "23.46.1",
+      "commands": [
+        "nd-codegen"
+      ]
     }
   }
+}

--- a/src/NetDaemon.Templates.Project/templates/netdaemon/NetDaemonApps.csproj
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon/NetDaemonApps.csproj
@@ -26,13 +26,13 @@
     </Target>
         
     <ItemGroup>
-        <PackageReference Include="NetDaemon.AppModel" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.Runtime" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.HassModel" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.Client" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.Extensions.Logging" Version="23.46.0" />
-        <PackageReference Include="NetDaemon.Extensions.Tts" Version="23.46.0" />
+        <PackageReference Include="NetDaemon.AppModel" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.Runtime" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.HassModel" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.Client" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.Extensions.Logging" Version="23.46.1" />
+        <PackageReference Include="NetDaemon.Extensions.Tts" Version="23.46.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
         <PackageReference Include="System.Reactive" Version="6.0.0" />

--- a/src/NetDaemon.Templates.Project/templates/netdaemon_src/.config/dotnet-tools.json
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon_src/.config/dotnet-tools.json
@@ -1,12 +1,12 @@
 {
-    "version": 1,
-    "isRoot": true,
-    "tools": {
-      "joysoftware.netdaemon.hassmodel.codegen": {
-        "version": "22.34.0",
-        "commands": [
-          "nd-codegen"
-        ]
-      }
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "netdaemon.hassmodel.codegen": {
+      "version": "23.46.1",
+      "commands": [
+        "nd-codegen"
+      ]
     }
   }
+}

--- a/src/NetDaemon.Templates.Project/templates/netdaemon_src/Debug.csproj
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon_src/Debug.csproj
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NetDaemon.AppModel" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.AppModel.SourceDeployedApps" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.Runtime" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.HassModel" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.Client" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.Extensions.Logging" Version="23.46.0" />
-    <PackageReference Include="NetDaemon.Extensions.Tts" Version="23.46.0" />
+    <PackageReference Include="NetDaemon.AppModel" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.AppModel.SourceDeployedApps" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.Runtime" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.HassModel" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.Client" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.Extensions.Scheduling" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.Extensions.Logging" Version="23.46.1" />
+    <PackageReference Include="NetDaemon.Extensions.Tts" Version="23.46.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />


### PR DESCRIPTION
Fixes an issue where I was getting the following error after trying to run codegen after creating a project from the template. 

```
> dotnet tool run nd-codegen
Connecting to Home Assistant at homeassistant.local:8123
Unhandled exception. System.Text.Json.JsonException: The JSON value could not be converted to NetDaemon.HassModel.CodeGenerator.Model.EntitySelector. Path: $.entity | LineNumber: 0 | BytePositionInLine: 11.
   at System.Text.Json.ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCoreAsObject(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo jsonTypeInfo, Nullable`1 actualByteCount)
   at System.Text.Json.JsonSerializer.Deserialize(ReadOnlySpan`1 utf8Json, Type returnType, JsonSerializerOptions options)
   at NetDaemon.HassModel.CodeGenerator.Model.JsonExtensions.<ToServicesResult>g__getSelector|1_2(String selectorName, JsonElement element, <>c__DisplayClass1_0& ) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs:line 103
   at NetDaemon.HassModel.CodeGenerator.Model.JsonExtensions.<ToServicesResult>g__getServiceFields|1_1(String service, JsonElement element, <>c__DisplayClass1_0& ) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs:line 69
   at NetDaemon.HassModel.CodeGenerator.Model.JsonExtensions.<ToServicesResult>g__getServices|1_0(JsonElement element, <>c__DisplayClass1_0& ) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs:line 40
   at NetDaemon.HassModel.CodeGenerator.Model.JsonExtensions.ToServicesResult(JsonElement element) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Model/JsonExtensions.cs:line 27
   at Program.<<Main>$>g__GetHaData|0_3(HomeAssistantSettings homeAssistantSettings) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs:line 122
   at Program.<<Main>$>g__GetHaData|0_3(HomeAssistantSettings homeAssistantSettings) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs:line 126
   at Program.<Main>$(String[] args) in /home/runner/work/netdaemon/netdaemon/src/HassModel/NetDaemon.HassModel.CodeGenerator/Program.cs:line 42
   at Program.<Main>(String[] args)
```