### PR TITLE
Set very high version number for running nd-codegen

### DIFF
--- a/src/NetDaemon.Templates.Project/templates/netdaemon/.config/dotnet-tools.json
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "netdaemon.hassmodel.codegen": {
-      "version": "23.46.1",
+      "version": "1000",
       "commands": [
         "nd-codegen"
       ]

--- a/src/NetDaemon.Templates.Project/templates/netdaemon_src/.config/dotnet-tools.json
+++ b/src/NetDaemon.Templates.Project/templates/netdaemon_src/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "netdaemon.hassmodel.codegen": {
-      "version": "23.46.1",
+      "version": "1000",
       "commands": [
         "nd-codegen"
       ]


### PR DESCRIPTION
If a specific version is set in dotnet-tools.json, then updating nd-codegen package does not have an effect, as the package is updated but then nd-codegen runs old specified version.

Setting a very high version number appears to make nd-codegen always run latest installed version and makes 'dotnet tool update -g NetDaemon.HassModel.CodeGen' always get latest version.